### PR TITLE
bugfix: use extra args in parser

### DIFF
--- a/protobuf-codegen/src/codegen/mod.rs
+++ b/protobuf-codegen/src/codegen/mod.rs
@@ -243,6 +243,7 @@ impl Codegen {
 
         parser.inputs(&self.inputs);
         parser.includes(&self.includes);
+        parser.protoc_extra_args(&self.protoc_extra_args);
 
         if self.capture_stderr {
             parser.capture_stderr();


### PR DESCRIPTION
Fixes the bug which does not include extra arguments into generator parser.